### PR TITLE
refactor(api): standardize problem details contract

### DIFF
--- a/docs/explanation/http-api-conventions.md
+++ b/docs/explanation/http-api-conventions.md
@@ -3,7 +3,7 @@ title: HTTP API Conventions
 status: accepted
 author: Codex
 created: 2026-03-13
-updated: 2026-04-01
+updated: 2026-04-08
 owner: Engineering
 doc-type: explanation
 summary: Explain the conventional REST and OpenAPI rules used for Dictum control-plane endpoints.
@@ -58,6 +58,47 @@ Use Problem Details for HTTP APIs.
 - Dictum extends Problem Details with a stable `code` and structured `params`.
 - Backend code owns `type`, `code`, `params`, and fallback problem text.
 - Frontend code should render user-facing API errors from `code` and `params`.
+
+#### Problem Field Semantics
+
+- `title` is a coarse generic problem label.
+- `detail` is fallback or diagnostic text and not primary UX copy.
+- `code` is the stable machine-readable client key.
+- `params` contains stable interpolation values only.
+
+#### Problem Code Taxonomy
+
+Problem codes should follow `domain.reason`.
+
+Examples:
+
+- `post.not_found`
+- `post.already_exists`
+- `auth.unauthenticated`
+- `request.invalid`
+- `request.method_not_allowed`
+
+The code should stay stable even when fallback text changes.
+
+#### Problem Params
+
+Use `params` only for stable structured values that clients can safely interpolate.
+
+Good examples:
+
+- `slug`
+- `field`
+- `contentType`
+- `method`
+
+Do not put prose, rendered sentences, or localization-oriented copy into `params`.
+
+#### Client Rendering Contract
+
+- Clients should localize API-originated messages from `code`.
+- Clients should interpolate those messages with `params`.
+- Clients should not rely on `title` or `detail` for localization logic.
+- `detail` is intended for fallback and debugging rather than primary user-facing copy.
 
 ### Authentication
 

--- a/docs/openapi/dictum.yaml
+++ b/docs/openapi/dictum.yaml
@@ -68,6 +68,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SessionResponse"
+        "400":
+          $ref: "#/components/responses/ProblemResponse"
         "401":
           $ref: "#/components/responses/ProblemResponse"
         default:
@@ -132,6 +134,8 @@ paths:
                         - admin
                         - control-plane
                       hasStylesheet: false
+        "401":
+          $ref: "#/components/responses/ProblemResponse"
         default:
           $ref: "#/components/responses/ProblemResponse"
     post:
@@ -177,6 +181,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PostResponse"
+        "400":
+          $ref: "#/components/responses/ProblemResponse"
         "401":
           $ref: "#/components/responses/ProblemResponse"
         "409":
@@ -260,6 +266,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PostResponse"
+        "400":
+          $ref: "#/components/responses/ProblemResponse"
         "401":
           $ref: "#/components/responses/ProblemResponse"
         "403":
@@ -354,6 +362,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SiteSettingsResponse"
+        "400":
+          $ref: "#/components/responses/ProblemResponse"
         "401":
           $ref: "#/components/responses/ProblemResponse"
         "403":
@@ -396,6 +406,34 @@ components:
                 params:
                   slug: remote-controls-later
                 detail: No post exists for slug remote-controls-later
+                instance: /api/v1/posts/remote-controls-later
+            unauthenticated:
+              value:
+                type: https://dictum.dev/problems/unauthenticated
+                title: Authentication required
+                status: 401
+                code: auth.unauthenticated
+                params: {}
+                detail: Authentication is required to access this resource.
+                instance: /api/v1/posts
+            invalidRequest:
+              value:
+                type: https://dictum.dev/problems/bad-request
+                title: Bad request
+                status: 400
+                code: request.invalid
+                params: {}
+                detail: "JSON parse error: Unexpected character"
+                instance: /api/v1/posts
+            methodNotAllowed:
+              value:
+                type: https://dictum.dev/problems/method-not-allowed
+                title: Method not allowed
+                status: 405
+                code: request.method_not_allowed
+                params:
+                  method: PUT
+                detail: Request method 'PUT' is not supported.
                 instance: /api/v1/posts/remote-controls-later
   schemas:
     CreateSessionRequest:
@@ -597,26 +635,34 @@ components:
         type:
           type: string
           format: uri-reference
+          description: Canonical semantic identifier for the problem type.
         title:
           type: string
+          description: Coarse generic problem label.
         status:
           type: integer
           minimum: 100
           maximum: 599
+          description: HTTP status code associated with the problem.
         detail:
           type: string
+          description: Fallback or diagnostic text for logs, debugging, or non-localized clients.
         instance:
           type: string
           format: uri-reference
+          description: Request-local identifier for the failing resource or route.
         code:
           type: string
-          description: Stable machine-readable problem code for client handling and localization.
+          description: Stable machine-readable problem code following the `domain.reason` convention.
         params:
           $ref: "#/components/schemas/ProblemParams"
           description: Structured interpolation values associated with the problem code.
     ProblemParams:
       type: object
       additionalProperties: true
+      description: >
+        Stable structured interpolation values such as `slug`, `field`, `contentType`, or
+        `method`. Do not place prose or localized copy in this object.
   securitySchemes:
     SessionCookieAuth:
       type: apiKey

--- a/packages/api-client/src/generated/models/ProblemDetails.ts
+++ b/packages/api-client/src/generated/models/ProblemDetails.ts
@@ -20,42 +20,43 @@ import { mapValues } from '../runtime';
  */
 export interface ProblemDetails {
     /**
-     * 
+     * Canonical semantic identifier for the problem type.
      * @type {string}
      * @memberof ProblemDetails
      */
     type?: string;
     /**
-     * 
+     * Coarse generic problem label.
      * @type {string}
      * @memberof ProblemDetails
      */
     title: string;
     /**
-     * 
+     * HTTP status code associated with the problem.
      * @type {number}
      * @memberof ProblemDetails
      */
     status: number;
     /**
-     * 
+     * Fallback or diagnostic text for logs, debugging, or non-localized clients.
      * @type {string}
      * @memberof ProblemDetails
      */
     detail?: string;
     /**
-     * 
+     * Request-local identifier for the failing resource or route.
      * @type {string}
      * @memberof ProblemDetails
      */
     instance?: string;
     /**
-     * Stable machine-readable problem code for client handling and localization.
+     * Stable machine-readable problem code following the `domain.reason` convention.
      * @type {string}
      * @memberof ProblemDetails
      */
     code: string;
     /**
+     * Stable structured interpolation values such as `slug`, `field`, `contentType`, or `method`. Do not place prose or localized copy in this object.
      * 
      * @type {object}
      * @memberof ProblemDetails

--- a/services/api/src/main/java/dev/dictum/api/web/error/ApiProblemHandler.java
+++ b/services/api/src/main/java/dev/dictum/api/web/error/ApiProblemHandler.java
@@ -11,9 +11,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class ApiProblemHandler {
@@ -67,6 +70,28 @@ public class ApiProblemHandler {
   public ResponseEntity<ProblemDetails> handleBadRequest(
       Exception exception, HttpServletRequest request) {
     return problem(ApiProblemSpec.badRequest(), exception.getMessage(), request);
+  }
+
+  @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
+  public ResponseEntity<ProblemDetails> handleRequestNotFound(
+      Exception exception, HttpServletRequest request) {
+    ApiProblemSpec spec =
+        switch (exception) {
+          case NoHandlerFoundException noHandlerFound ->
+              ApiProblemSpec.requestNotFound(noHandlerFound);
+          case NoResourceFoundException noResourceFound ->
+              ApiProblemSpec.requestNotFound(noResourceFound);
+          default ->
+              throw new IllegalArgumentException("Unsupported not-found exception: " + exception);
+        };
+
+    return problem(spec, exception.getMessage(), request);
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<ProblemDetails> handleMethodNotAllowed(
+      HttpRequestMethodNotSupportedException exception, HttpServletRequest request) {
+    return problem(ApiProblemSpec.methodNotAllowed(exception), exception.getMessage(), request);
   }
 
   @ExceptionHandler(InvalidCredentialsException.class)

--- a/services/api/src/main/java/dev/dictum/api/web/error/ApiProblemHandler.java
+++ b/services/api/src/main/java/dev/dictum/api/web/error/ApiProblemHandler.java
@@ -75,17 +75,7 @@ public class ApiProblemHandler {
   @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
   public ResponseEntity<ProblemDetails> handleRequestNotFound(
       Exception exception, HttpServletRequest request) {
-    ApiProblemSpec spec =
-        switch (exception) {
-          case NoHandlerFoundException noHandlerFound ->
-              ApiProblemSpec.requestNotFound(noHandlerFound);
-          case NoResourceFoundException noResourceFound ->
-              ApiProblemSpec.requestNotFound(noResourceFound);
-          default ->
-              throw new IllegalArgumentException("Unsupported not-found exception: " + exception);
-        };
-
-    return problem(spec, exception.getMessage(), request);
+    return problem(ApiProblemSpec.requestNotFound(), exception.getMessage(), request);
   }
 
   @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
@@ -97,7 +87,7 @@ public class ApiProblemHandler {
   @ExceptionHandler(InvalidCredentialsException.class)
   public ResponseEntity<ProblemDetails> handleInvalidCredentials(
       InvalidCredentialsException exception, HttpServletRequest request) {
-    return problem(ApiProblemSpec.invalidCredentials(exception), exception.getMessage(), request);
+    return problem(ApiProblemSpec.invalidCredentials(), exception.getMessage(), request);
   }
 
   private ResponseEntity<ProblemDetails> problem(

--- a/services/api/src/main/java/dev/dictum/api/web/error/ApiProblemSpec.java
+++ b/services/api/src/main/java/dev/dictum/api/web/error/ApiProblemSpec.java
@@ -8,6 +8,9 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 record ApiProblemSpec(
     HttpStatus status, String type, String title, String code, Map<String, Object> params) {
@@ -79,6 +82,32 @@ record ApiProblemSpec(
         "Bad request",
         "request.invalid",
         Map.of());
+  }
+
+  static ApiProblemSpec requestNotFound() {
+    return new ApiProblemSpec(
+        HttpStatus.NOT_FOUND,
+        problemType("request-not-found"),
+        "Resource not found",
+        "request.not_found",
+        Map.of());
+  }
+
+  static ApiProblemSpec requestNotFound(NoResourceFoundException exception) {
+    return requestNotFound();
+  }
+
+  static ApiProblemSpec requestNotFound(NoHandlerFoundException exception) {
+    return requestNotFound();
+  }
+
+  static ApiProblemSpec methodNotAllowed(HttpRequestMethodNotSupportedException exception) {
+    return new ApiProblemSpec(
+        HttpStatus.METHOD_NOT_ALLOWED,
+        problemType("method-not-allowed"),
+        "Method not allowed",
+        "request.method_not_allowed",
+        exception.getMethod() == null ? Map.of() : Map.of("method", exception.getMethod()));
   }
 
   static ApiProblemSpec invalidCredentials(InvalidCredentialsException exception) {

--- a/services/api/src/main/java/dev/dictum/api/web/error/ApiProblemSpec.java
+++ b/services/api/src/main/java/dev/dictum/api/web/error/ApiProblemSpec.java
@@ -1,6 +1,5 @@
 package dev.dictum.api.web.error;
 
-import dev.dictum.api.auth.error.InvalidCredentialsException;
 import dev.dictum.api.content.error.PostAlreadyExistsException;
 import dev.dictum.api.content.error.PostAlreadyPublishedException;
 import dev.dictum.api.content.error.PostNotFoundException;
@@ -9,12 +8,11 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
-import org.springframework.web.servlet.NoHandlerFoundException;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 record ApiProblemSpec(
     HttpStatus status, String type, String title, String code, Map<String, Object> params) {
 
+  private static final String BAD_REQUEST_TITLE = "Bad request";
   private static final String PROBLEM_BASE_URL = "https://dictum.dev/problems/";
 
   ApiProblemSpec {
@@ -52,7 +50,7 @@ record ApiProblemSpec(
     return new ApiProblemSpec(
         HttpStatus.BAD_REQUEST,
         problemType("invalid-patch-request"),
-        "Bad request",
+        BAD_REQUEST_TITLE,
         "patch.invalid",
         Map.of());
   }
@@ -61,7 +59,7 @@ record ApiProblemSpec(
     return new ApiProblemSpec(
         HttpStatus.BAD_REQUEST,
         problemType("invalid-post-request"),
-        "Bad request",
+        BAD_REQUEST_TITLE,
         "post.invalid",
         Map.of());
   }
@@ -79,7 +77,7 @@ record ApiProblemSpec(
     return new ApiProblemSpec(
         HttpStatus.BAD_REQUEST,
         problemType("bad-request"),
-        "Bad request",
+        BAD_REQUEST_TITLE,
         "request.invalid",
         Map.of());
   }
@@ -93,14 +91,6 @@ record ApiProblemSpec(
         Map.of());
   }
 
-  static ApiProblemSpec requestNotFound(NoResourceFoundException exception) {
-    return requestNotFound();
-  }
-
-  static ApiProblemSpec requestNotFound(NoHandlerFoundException exception) {
-    return requestNotFound();
-  }
-
   static ApiProblemSpec methodNotAllowed(HttpRequestMethodNotSupportedException exception) {
     return new ApiProblemSpec(
         HttpStatus.METHOD_NOT_ALLOWED,
@@ -110,7 +100,7 @@ record ApiProblemSpec(
         exception.getMethod() == null ? Map.of() : Map.of("method", exception.getMethod()));
   }
 
-  static ApiProblemSpec invalidCredentials(InvalidCredentialsException exception) {
+  static ApiProblemSpec invalidCredentials() {
     return new ApiProblemSpec(
         HttpStatus.UNAUTHORIZED,
         problemType("invalid-credentials"),

--- a/services/api/src/test/java/dev/dictum/api/HttpContractTest.java
+++ b/services/api/src/test/java/dev/dictum/api/HttpContractTest.java
@@ -160,6 +160,51 @@ class HttpContractTest {
   }
 
   @Test
+  void missingApiRouteReturnsProblemDetails() throws Exception {
+    HttpResponse<String> response =
+        sessionHttpClient.getAuthenticated("/api/v1/missing", ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    assertThat(response.statusCode()).isEqualTo(404);
+    assertThat(response.headers().firstValue(CONTENT_TYPE_HEADER))
+        .hasValueSatisfying(
+            value -> assertThat(value).contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+
+    JsonNode problem = objectMapper.readTree(response.body());
+    assertThat(problem.get("type").asText())
+        .isEqualTo("https://dictum.dev/problems/request-not-found");
+    assertThat(problem.get("title").asText()).isEqualTo("Resource not found");
+    assertThat(problem.get("code").asText()).isEqualTo("request.not_found");
+    assertThat(problem.get(PARAMS_FIELD).isEmpty()).isTrue();
+    assertThat(problem.get("status").asInt()).isEqualTo(404);
+  }
+
+  @Test
+  void unsupportedMethodReturnsProblemDetails() throws Exception {
+    sessionHttpClient.createSession(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    HttpResponse<String> response =
+        sessionHttpClient.request(
+            HttpMethod.PUT,
+            REMOTE_CONTROLS_LATER_PATH,
+            MediaType.APPLICATION_JSON_VALUE,
+            "{\"title\":\"Wrong method\"}",
+            true);
+
+    assertThat(response.statusCode()).isEqualTo(405);
+    assertThat(response.headers().firstValue(CONTENT_TYPE_HEADER))
+        .hasValueSatisfying(
+            value -> assertThat(value).contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+
+    JsonNode problem = objectMapper.readTree(response.body());
+    assertThat(problem.get("type").asText())
+        .isEqualTo("https://dictum.dev/problems/method-not-allowed");
+    assertThat(problem.get("title").asText()).isEqualTo("Method not allowed");
+    assertThat(problem.get("code").asText()).isEqualTo("request.method_not_allowed");
+    assertThat(problem.get(PARAMS_FIELD).get("method").asText()).isEqualTo("PUT");
+    assertThat(problem.get("status").asInt()).isEqualTo(405);
+  }
+
+  @Test
   void createPostReturnsCreatedResourceAndLocationHeader() throws Exception {
     HttpResponse<String> response =
         sessionHttpClient.requestAuthenticated(

--- a/services/api/src/test/java/dev/dictum/api/PostsHttpContractTest.java
+++ b/services/api/src/test/java/dev/dictum/api/PostsHttpContractTest.java
@@ -12,6 +12,9 @@ import org.springframework.http.MediaType;
 
 class PostsHttpContractTest extends InMemoryHttpContractSupport {
 
+  private static final String STATUS_FIELD = "status";
+  private static final String TITLE_FIELD = "title";
+
   @Test
   void protectedEndpointsRejectUnauthenticatedRequests() throws Exception {
     HttpResponse<String> response = sessionHttpClient.get(POSTS_PATH);
@@ -26,7 +29,9 @@ class PostsHttpContractTest extends InMemoryHttpContractSupport {
   void unsafeProtectedEndpointsReturnUnauthenticatedProblemWhenNoSessionExists() throws Exception {
     HttpResponse<String> response =
         sessionHttpClient.patchWithoutCsrf(
-            REMOTE_CONTROLS_LATER_PATH, MERGE_PATCH_JSON, "{\"title\":\"No session\"}");
+            REMOTE_CONTROLS_LATER_PATH,
+            MERGE_PATCH_JSON,
+            "{\"%s\":\"No session\"}".formatted(TITLE_FIELD));
 
     assertThat(response.statusCode()).isEqualTo(401);
 
@@ -48,7 +53,7 @@ class PostsHttpContractTest extends InMemoryHttpContractSupport {
     assertThat(posts.isArray()).isTrue();
     assertThat(posts).hasSize(2);
     assertThat(posts.get(0).get("slug").asText()).isEqualTo(DICTUM_BEGINS_SLUG);
-    assertThat(posts.get(0).get("status").asText()).isEqualTo("published");
+    assertThat(posts.get(0).get(STATUS_FIELD).asText()).isEqualTo("published");
     assertThat(posts.get(1).get("slug").asText()).isEqualTo(REMOTE_CONTROLS_LATER_SLUG);
   }
 
@@ -80,10 +85,10 @@ class PostsHttpContractTest extends InMemoryHttpContractSupport {
     JsonNode problem = objectMapper.readTree(response.body());
     assertThat(problem.get("type").asText())
         .isEqualTo("https://dictum.dev/problems/post-not-found");
-    assertThat(problem.get("title").asText()).isEqualTo("Resource not found");
+    assertThat(problem.get(TITLE_FIELD).asText()).isEqualTo("Resource not found");
     assertThat(problem.get("code").asText()).isEqualTo("post.not_found");
     assertThat(problem.get(PARAMS_FIELD).get("slug").asText()).isEqualTo(UNKNOWN_SLUG);
-    assertThat(problem.get("status").asInt()).isEqualTo(404);
+    assertThat(problem.get(STATUS_FIELD).asInt()).isEqualTo(404);
   }
 
   @Test
@@ -99,10 +104,10 @@ class PostsHttpContractTest extends InMemoryHttpContractSupport {
     JsonNode problem = objectMapper.readTree(response.body());
     assertThat(problem.get("type").asText())
         .isEqualTo("https://dictum.dev/problems/request-not-found");
-    assertThat(problem.get("title").asText()).isEqualTo("Resource not found");
+    assertThat(problem.get(TITLE_FIELD).asText()).isEqualTo("Resource not found");
     assertThat(problem.get("code").asText()).isEqualTo("request.not_found");
     assertThat(problem.get(PARAMS_FIELD).isEmpty()).isTrue();
-    assertThat(problem.get("status").asInt()).isEqualTo(404);
+    assertThat(problem.get(STATUS_FIELD).asInt()).isEqualTo(404);
   }
 
   @Test
@@ -114,7 +119,7 @@ class PostsHttpContractTest extends InMemoryHttpContractSupport {
             HttpMethod.PUT,
             REMOTE_CONTROLS_LATER_PATH,
             MediaType.APPLICATION_JSON_VALUE,
-            "{\"title\":\"Wrong method\"}",
+            "{\"%s\":\"Wrong method\"}".formatted(TITLE_FIELD),
             true);
 
     assertThat(response.statusCode()).isEqualTo(405);
@@ -125,10 +130,10 @@ class PostsHttpContractTest extends InMemoryHttpContractSupport {
     JsonNode problem = objectMapper.readTree(response.body());
     assertThat(problem.get("type").asText())
         .isEqualTo("https://dictum.dev/problems/method-not-allowed");
-    assertThat(problem.get("title").asText()).isEqualTo("Method not allowed");
+    assertThat(problem.get(TITLE_FIELD).asText()).isEqualTo("Method not allowed");
     assertThat(problem.get("code").asText()).isEqualTo("request.method_not_allowed");
     assertThat(problem.get(PARAMS_FIELD).get("method").asText()).isEqualTo("PUT");
-    assertThat(problem.get("status").asInt()).isEqualTo(405);
+    assertThat(problem.get(STATUS_FIELD).asInt()).isEqualTo(405);
   }
 
   @Test
@@ -251,7 +256,7 @@ class PostsHttpContractTest extends InMemoryHttpContractSupport {
             HttpMethod.PATCH,
             REMOTE_CONTROLS_LATER_PATH,
             MediaType.APPLICATION_JSON_VALUE,
-            "{\"title\":\"Wrong media type\"}",
+            "{\"%s\":\"Wrong media type\"}".formatted(TITLE_FIELD),
             ADMIN_USERNAME,
             ADMIN_PASSWORD);
 

--- a/services/api/src/test/java/dev/dictum/api/PostsHttpContractTest.java
+++ b/services/api/src/test/java/dev/dictum/api/PostsHttpContractTest.java
@@ -3,87 +3,14 @@ package dev.dictum.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.dictum.api.generated.model.PostResponse;
-import dev.dictum.api.generated.model.SessionResponse;
-import dev.dictum.api.generated.model.SiteSettingsResponse;
-import dev.dictum.api.support.SessionHttpClient;
+import dev.dictum.api.support.InMemoryHttpContractSupport;
 import dev.dictum.api.support.SessionHttpClient.HttpMethod;
-import dev.dictum.api.support.TestAdminCredentials;
 import java.net.http.HttpResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = {
-      "dictum.content.repository=in-memory",
-      TestAdminCredentials.USERNAME_PROPERTY,
-      TestAdminCredentials.PASSWORD_PROPERTY
-    })
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class HttpContractTest {
-
-  private static final String CONTENT_TYPE_HEADER = "content-type";
-  private static final String MERGE_PATCH_JSON = "application/merge-patch+json";
-  private static final String PARAMS_FIELD = "params";
-  private static final String POSTS_SEGMENT = "posts";
-  private static final String DICTUM_BEGINS_SLUG = "dictum-begins";
-  private static final String REMOTE_CONTROLS_LATER_SLUG = "remote-controls-later";
-  private static final String UNKNOWN_SLUG = "unknown-slug";
-  private static final String ADMIN_TAG = "admin";
-  private static final String API_TAG = "api";
-  private static final String SESSION_PATH = path("api", "v1", "session");
-  private static final String POSTS_PATH = path("api", "v1", POSTS_SEGMENT);
-  private static final String REMOTE_CONTROLS_LATER_PATH =
-      path("api", "v1", POSTS_SEGMENT, REMOTE_CONTROLS_LATER_SLUG);
-  private static final String SITE_SETTINGS_PATH = path("api", "v1", "settings", "site");
-  private static final String ADMIN_USERNAME = TestAdminCredentials.USERNAME;
-  private static final String ADMIN_PASSWORD = TestAdminCredentials.SECRET;
-
-  private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
-  private SessionHttpClient sessionHttpClient;
-
-  @LocalServerPort private int port;
-
-  @BeforeEach
-  void setUp() {
-    sessionHttpClient = new SessionHttpClient(baseUrl(), objectMapper);
-  }
-
-  @Test
-  void getSessionReturnsCurrentAuthenticatedSession() throws Exception {
-    HttpResponse<String> loginResponse =
-        sessionHttpClient.createSession(ADMIN_USERNAME, ADMIN_PASSWORD);
-
-    assertThat(loginResponse.statusCode()).isEqualTo(200);
-
-    HttpResponse<String> response = sessionHttpClient.get(SESSION_PATH);
-
-    assertThat(response.statusCode()).isEqualTo(200);
-
-    SessionResponse session = objectMapper.readValue(response.body(), SessionResponse.class);
-    assertThat(session.getUsername()).isEqualTo(ADMIN_USERNAME);
-    assertThat(session.getCsrfToken()).isNotBlank();
-  }
-
-  @Test
-  void createSessionRejectsInvalidCredentials() throws Exception {
-    HttpResponse<String> response =
-        sessionHttpClient.createSession(ADMIN_USERNAME, "wrong-password");
-
-    assertThat(response.statusCode()).isEqualTo(401);
-    assertThat(response.headers().firstValue(CONTENT_TYPE_HEADER))
-        .hasValueSatisfying(
-            value -> assertThat(value).contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
-
-    JsonNode problem = objectMapper.readTree(response.body());
-    assertThat(problem.get("code").asText()).isEqualTo("auth.invalid_credentials");
-  }
+class PostsHttpContractTest extends InMemoryHttpContractSupport {
 
   @Test
   void protectedEndpointsRejectUnauthenticatedRequests() throws Exception {
@@ -397,44 +324,6 @@ class HttpContractTest {
   }
 
   @Test
-  void getSiteSettingsReturnsTheCurrentSiteValues() throws Exception {
-    HttpResponse<String> response =
-        sessionHttpClient.getAuthenticated(SITE_SETTINGS_PATH, ADMIN_USERNAME, ADMIN_PASSWORD);
-
-    assertThat(response.statusCode()).isEqualTo(200);
-
-    SiteSettingsResponse settings =
-        objectMapper.readValue(response.body(), SiteSettingsResponse.class);
-    assertThat(settings.getTitle()).isEqualTo("Dictum");
-    assertThat(settings.getSubtitle()).isEqualTo("A remotely steerable markdown blog kit.");
-  }
-
-  @Test
-  void updateSiteSettingsReturnsTheUpdatedRepresentation() throws Exception {
-    HttpResponse<String> response =
-        sessionHttpClient.requestAuthenticated(
-            HttpMethod.PATCH,
-            SITE_SETTINGS_PATH,
-            MERGE_PATCH_JSON,
-            """
-            {
-              "subtitle": "A modular markdown blog platform.",
-              "motd": "API-first contract work is underway."
-            }
-            """,
-            ADMIN_USERNAME,
-            ADMIN_PASSWORD);
-
-    assertThat(response.statusCode()).isEqualTo(200);
-
-    SiteSettingsResponse settings =
-        objectMapper.readValue(response.body(), SiteSettingsResponse.class);
-    assertThat(settings.getTitle()).isEqualTo("Dictum");
-    assertThat(settings.getSubtitle()).isEqualTo("A modular markdown blog platform.");
-    assertThat(settings.getMotd()).isEqualTo("API-first contract work is underway.");
-  }
-
-  @Test
   void unsafeRequestsRequireCsrfToken() throws Exception {
     sessionHttpClient.createSession(ADMIN_USERNAME, ADMIN_PASSWORD);
 
@@ -446,25 +335,5 @@ class HttpContractTest {
 
     JsonNode problem = objectMapper.readTree(response.body());
     assertThat(problem.get("code").asText()).isEqualTo("request.csrf_invalid");
-  }
-
-  @Test
-  void deleteSessionInvalidatesTheCurrentSession() throws Exception {
-    sessionHttpClient.createSession(ADMIN_USERNAME, ADMIN_PASSWORD);
-
-    HttpResponse<String> response = sessionHttpClient.delete(SESSION_PATH);
-
-    assertThat(response.statusCode()).isEqualTo(204);
-
-    HttpResponse<String> sessionResponse = sessionHttpClient.get(SESSION_PATH);
-    assertThat(sessionResponse.statusCode()).isEqualTo(401);
-  }
-
-  private String baseUrl() {
-    return "http://localhost:" + port;
-  }
-
-  private static String path(String... segments) {
-    return "/" + String.join("/", segments);
   }
 }

--- a/services/api/src/test/java/dev/dictum/api/SessionHttpContractTest.java
+++ b/services/api/src/test/java/dev/dictum/api/SessionHttpContractTest.java
@@ -1,0 +1,55 @@
+package dev.dictum.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import dev.dictum.api.generated.model.SessionResponse;
+import dev.dictum.api.support.InMemoryHttpContractSupport;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class SessionHttpContractTest extends InMemoryHttpContractSupport {
+
+  @Test
+  void getSessionReturnsCurrentAuthenticatedSession() throws Exception {
+    HttpResponse<String> loginResponse =
+        sessionHttpClient.createSession(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    assertThat(loginResponse.statusCode()).isEqualTo(200);
+
+    HttpResponse<String> response = sessionHttpClient.get(SESSION_PATH);
+
+    assertThat(response.statusCode()).isEqualTo(200);
+
+    SessionResponse session = objectMapper.readValue(response.body(), SessionResponse.class);
+    assertThat(session.getUsername()).isEqualTo(ADMIN_USERNAME);
+    assertThat(session.getCsrfToken()).isNotBlank();
+  }
+
+  @Test
+  void createSessionRejectsInvalidCredentials() throws Exception {
+    HttpResponse<String> response =
+        sessionHttpClient.createSession(ADMIN_USERNAME, "wrong-password");
+
+    assertThat(response.statusCode()).isEqualTo(401);
+    assertThat(response.headers().firstValue(CONTENT_TYPE_HEADER))
+        .hasValueSatisfying(
+            value -> assertThat(value).contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+
+    JsonNode problem = objectMapper.readTree(response.body());
+    assertThat(problem.get("code").asText()).isEqualTo("auth.invalid_credentials");
+  }
+
+  @Test
+  void deleteSessionInvalidatesTheCurrentSession() throws Exception {
+    sessionHttpClient.createSession(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    HttpResponse<String> response = sessionHttpClient.delete(SESSION_PATH);
+
+    assertThat(response.statusCode()).isEqualTo(204);
+
+    HttpResponse<String> sessionResponse = sessionHttpClient.get(SESSION_PATH);
+    assertThat(sessionResponse.statusCode()).isEqualTo(401);
+  }
+}

--- a/services/api/src/test/java/dev/dictum/api/SiteSettingsHttpContractTest.java
+++ b/services/api/src/test/java/dev/dictum/api/SiteSettingsHttpContractTest.java
@@ -1,0 +1,50 @@
+package dev.dictum.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.dictum.api.generated.model.SiteSettingsResponse;
+import dev.dictum.api.support.InMemoryHttpContractSupport;
+import dev.dictum.api.support.SessionHttpClient.HttpMethod;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+
+class SiteSettingsHttpContractTest extends InMemoryHttpContractSupport {
+
+  @Test
+  void getSiteSettingsReturnsTheCurrentSiteValues() throws Exception {
+    HttpResponse<String> response =
+        sessionHttpClient.getAuthenticated(SITE_SETTINGS_PATH, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    assertThat(response.statusCode()).isEqualTo(200);
+
+    SiteSettingsResponse settings =
+        objectMapper.readValue(response.body(), SiteSettingsResponse.class);
+    assertThat(settings.getTitle()).isEqualTo("Dictum");
+    assertThat(settings.getSubtitle()).isEqualTo("A remotely steerable markdown blog kit.");
+  }
+
+  @Test
+  void updateSiteSettingsReturnsTheUpdatedRepresentation() throws Exception {
+    HttpResponse<String> response =
+        sessionHttpClient.requestAuthenticated(
+            HttpMethod.PATCH,
+            SITE_SETTINGS_PATH,
+            MERGE_PATCH_JSON,
+            """
+            {
+              "subtitle": "A modular markdown blog platform.",
+              "motd": "API-first contract work is underway."
+            }
+            """,
+            ADMIN_USERNAME,
+            ADMIN_PASSWORD);
+
+    assertThat(response.statusCode()).isEqualTo(200);
+
+    SiteSettingsResponse settings =
+        objectMapper.readValue(response.body(), SiteSettingsResponse.class);
+    assertThat(settings.getTitle()).isEqualTo("Dictum");
+    assertThat(settings.getSubtitle()).isEqualTo("A modular markdown blog platform.");
+    assertThat(settings.getMotd()).isEqualTo("API-first contract work is underway.");
+  }
+}

--- a/services/api/src/test/java/dev/dictum/api/support/InMemoryHttpContractSupport.java
+++ b/services/api/src/test/java/dev/dictum/api/support/InMemoryHttpContractSupport.java
@@ -1,0 +1,53 @@
+package dev.dictum.api.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "dictum.content.repository=in-memory",
+      TestAdminCredentials.USERNAME_PROPERTY,
+      TestAdminCredentials.PASSWORD_PROPERTY
+    })
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public abstract class InMemoryHttpContractSupport {
+
+  protected static final String CONTENT_TYPE_HEADER = "content-type";
+  protected static final String MERGE_PATCH_JSON = "application/merge-patch+json";
+  protected static final String PARAMS_FIELD = "params";
+  protected static final String POSTS_SEGMENT = "posts";
+  protected static final String DICTUM_BEGINS_SLUG = "dictum-begins";
+  protected static final String REMOTE_CONTROLS_LATER_SLUG = "remote-controls-later";
+  protected static final String UNKNOWN_SLUG = "unknown-slug";
+  protected static final String ADMIN_TAG = "admin";
+  protected static final String API_TAG = "api";
+  protected static final String SESSION_PATH = path("api", "v1", "session");
+  protected static final String POSTS_PATH = path("api", "v1", POSTS_SEGMENT);
+  protected static final String REMOTE_CONTROLS_LATER_PATH =
+      path("api", "v1", POSTS_SEGMENT, REMOTE_CONTROLS_LATER_SLUG);
+  protected static final String SITE_SETTINGS_PATH = path("api", "v1", "settings", "site");
+  protected static final String ADMIN_USERNAME = TestAdminCredentials.USERNAME;
+  protected static final String ADMIN_PASSWORD = TestAdminCredentials.SECRET;
+
+  protected final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+  protected SessionHttpClient sessionHttpClient;
+
+  @LocalServerPort private int port;
+
+  @BeforeEach
+  void setUpHttpClient() {
+    sessionHttpClient = new SessionHttpClient(baseUrl(), objectMapper);
+  }
+
+  protected String baseUrl() {
+    return "http://localhost:" + port;
+  }
+
+  protected static String path(String... segments) {
+    return "/" + String.join("/", segments);
+  }
+}

--- a/services/api/src/test/java/dev/dictum/api/support/SessionHttpClient.java
+++ b/services/api/src/test/java/dev/dictum/api/support/SessionHttpClient.java
@@ -82,6 +82,11 @@ public class SessionHttpClient {
     return request(HttpMethod.DELETE, path, null, null, true);
   }
 
+  public HttpResponse<String> put(String path, String contentType, String body)
+      throws IOException, InterruptedException {
+    return request(HttpMethod.PUT, path, contentType, body, true);
+  }
+
   public HttpResponse<String> requestAuthenticated(
       HttpMethod method,
       String path,
@@ -124,6 +129,13 @@ public class SessionHttpClient {
                           ? HttpRequest.BodyPublishers.noBody()
                           : HttpRequest.BodyPublishers.ofString(body))
                   .build();
+          case PUT ->
+              builder
+                  .PUT(
+                      body == null
+                          ? HttpRequest.BodyPublishers.noBody()
+                          : HttpRequest.BodyPublishers.ofString(body))
+                  .build();
           case DELETE -> builder.DELETE().build();
           default -> builder.GET().build();
         };
@@ -135,6 +147,7 @@ public class SessionHttpClient {
     GET("GET"),
     POST("POST"),
     PATCH("PATCH"),
+    PUT("PUT"),
     DELETE("DELETE");
 
     private final String value;

--- a/services/api/src/test/java/dev/dictum/api/web/error/ApiProblemHandlerTest.java
+++ b/services/api/src/test/java/dev/dictum/api/web/error/ApiProblemHandlerTest.java
@@ -27,6 +27,7 @@ class ApiProblemHandlerTest {
   private static final String BAD_REQUEST_TITLE = "Bad request";
   private static final String DICTUM_BEGINS_SLUG = "dictum-begins";
   private static final String POST_PATH = path("api", "v1", "posts", DICTUM_BEGINS_SLUG);
+  private static final String RESOURCE_NOT_FOUND_TITLE = "Resource not found";
 
   private ApiProblemHandler apiProblemHandler;
   private MockHttpServletRequest request;
@@ -48,7 +49,7 @@ class ApiProblemHandlerTest {
     assertProblem(
         response.getBody(),
         "https://dictum.dev/problems/post-not-found",
-        "Resource not found",
+        RESOURCE_NOT_FOUND_TITLE,
         "post.not_found",
         Map.of("slug", "unknown-slug"),
         404,
@@ -168,7 +169,7 @@ class ApiProblemHandlerTest {
     assertProblem(
         response.getBody(),
         "https://dictum.dev/problems/request-not-found",
-        "Resource not found",
+        RESOURCE_NOT_FOUND_TITLE,
         "request.not_found",
         Map.of(),
         404,
@@ -187,7 +188,7 @@ class ApiProblemHandlerTest {
     assertProblem(
         response.getBody(),
         "https://dictum.dev/problems/request-not-found",
-        "Resource not found",
+        RESOURCE_NOT_FOUND_TITLE,
         "request.not_found",
         Map.of(),
         404,

--- a/services/api/src/test/java/dev/dictum/api/web/error/ApiProblemHandlerTest.java
+++ b/services/api/src/test/java/dev/dictum/api/web/error/ApiProblemHandlerTest.java
@@ -12,11 +12,15 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 class ApiProblemHandlerTest {
 
@@ -151,6 +155,59 @@ class ApiProblemHandlerTest {
         "request.invalid",
         Map.of(),
         400,
+        POST_PATH);
+  }
+
+  @Test
+  void handleRequestNotFoundReturnsNotFoundProblemDetailsForMissingRoute() {
+    var response =
+        apiProblemHandler.handleRequestNotFound(
+            new NoHandlerFoundException("GET", "/api/v1/missing", null), request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertProblem(
+        response.getBody(),
+        "https://dictum.dev/problems/request-not-found",
+        "Resource not found",
+        "request.not_found",
+        Map.of(),
+        404,
+        POST_PATH);
+  }
+
+  @Test
+  void handleRequestNotFoundReturnsNotFoundProblemDetailsForMissingStaticResource() {
+    var response =
+        apiProblemHandler.handleRequestNotFound(
+            new NoResourceFoundException(
+                HttpMethod.GET, "/api/v1/missing", "No static resource found"),
+            request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertProblem(
+        response.getBody(),
+        "https://dictum.dev/problems/request-not-found",
+        "Resource not found",
+        "request.not_found",
+        Map.of(),
+        404,
+        POST_PATH);
+  }
+
+  @Test
+  void handleMethodNotAllowedReturnsProblemDetails() {
+    var response =
+        apiProblemHandler.handleMethodNotAllowed(
+            new HttpRequestMethodNotSupportedException("PUT"), request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    assertProblem(
+        response.getBody(),
+        "https://dictum.dev/problems/method-not-allowed",
+        "Method not allowed",
+        "request.method_not_allowed",
+        Map.of("method", "PUT"),
+        405,
         POST_PATH);
   }
 


### PR DESCRIPTION
## Summary
- standardize fallback framework error paths so missing-route and method-not-allowed cases return the same `application/problem+json` contract as the rest of the API
- tighten the problem-details documentation and OpenAPI contract around `title`, `detail`, `code`, `params`, and the `domain.reason` code taxonomy
- split the in-memory HTTP contract suite by resource and move the shared bootstrapping into test support infrastructure
- clean the remaining SonarQube diagnostics on the touched problem-details and test files

## Testing
- `pnpm generate:api`
- `pnpm lint:api`
- `pnpm test:api`
- `pnpm lint:web`
- `pnpm typecheck:web`
- `DICTUM_SONAR_AUTO_START=true pnpm sonar:ide services/api/src/main/java/dev/dictum/api/web/error/ApiProblemHandler.java services/api/src/main/java/dev/dictum/api/web/error/ApiProblemSpec.java services/api/src/test/java/dev/dictum/api/PostsHttpContractTest.java services/api/src/test/java/dev/dictum/api/SessionHttpContractTest.java services/api/src/test/java/dev/dictum/api/SiteSettingsHttpContractTest.java services/api/src/test/java/dev/dictum/api/support/InMemoryHttpContractSupport.java services/api/src/test/java/dev/dictum/api/support/SessionHttpClient.java services/api/src/test/java/dev/dictum/api/web/error/ApiProblemHandlerTest.java`

## Risks
- problem response examples and fallback mappings changed together, so any client depending on previous undocumented fallback behavior should rely on the documented `code` and `params` contract instead
- the HTTP contract suite split changes test structure only; runtime behavior remains covered by the same end-to-end assertions

## Checklist
- [x] contract and runtime behavior were updated together
- [x] docs reflect the final behavior without meta-commentary
- [x] tests cover domain, validation, auth/security, and fallback framework error paths
